### PR TITLE
Refactor module map modal with tag service.

### DIFF
--- a/public/lessonBuilder/lessonItems.html
+++ b/public/lessonBuilder/lessonItems.html
@@ -8,7 +8,7 @@
        <h4><span class="badge">{{numQuizes}}</span>Quizes</h4>
        <h4><span class="badge">{{numDiscussions}}</span>Discussions</h4>
        <h4><span class="badge">{{numAssignments}}</span> Assignments</h4>
-       <learning-objective id="{{lo}}" ng-repeat="lo in module.learningObjectives"></learning-objective>
+       <learning-objective id="{{tag.content}}" ng-repeat="tag in module.tags"></learning-objective>
     </div>
     <div class="alert alert-info">
        <h4>Total Filtered: {{filtered.length}}</h4>

--- a/public/lessonBuilder/lessonItemsController.js
+++ b/public/lessonBuilder/lessonItemsController.js
@@ -1,23 +1,23 @@
 angular.module('newApp')
-.controller('lessonItems', function(modules, moduleItems, moduleMetadata, unitItems, $scope, $routeParams){
+.controller('lessonItems', function(modules, moduleItems, tags, $scope, $routeParams){
 
     $scope.radioModel = 'Lesson';
 
     $scope.matchType = function(query) {
-      return function(contentItem) {
-        if($scope.radioModel === 'All') 
-            return true;
-        else if($scope.radioModel === 'Lesson')
-            return contentItem.type.match('SubHeader');
-        else if($scope.radioModel === 'Quiz')
-            return contentItem.type.match('Quiz');
-        else if($scope.radioModel === 'Assignment')
-            return contentItem.type.match('Assignment');
-        else if($scope.radioModel === 'Discussion')
-            return contentItem.type.match('Discussion');
+        return function(contentItem) {
+            if($scope.radioModel === 'All') 
+                return true;
+            else if($scope.radioModel === 'Lesson')
+                return contentItem.type.match('SubHeader');
+            else if($scope.radioModel === 'Quiz')
+                return contentItem.type.match('Quiz');
+            else if($scope.radioModel === 'Assignment')
+                return contentItem.type.match('Assignment');
+            else if($scope.radioModel === 'Discussion')
+                return contentItem.type.match('Discussion');
         }
     };
- 
+
     function makePageMap(headers) {
         var pageObjs = {};
         var pageArr = headers.split(',').map(function(str) {
@@ -63,65 +63,65 @@ angular.module('newApp')
     }
 
     function findTeacherRes(modules, moduleName) {
-      for(i = 0; i < modules.length; i++) {
-        // find the module tha has moduleName AND "Teacher" in it.
-        if((modules[i].name.indexOf(moduleName) !== -1) &&
-              (modules[i].name.indexOf("Teacher") !== -1))
-          return modules[i];
-      }
+        for(i = 0; i < modules.length; i++) {
+            // find the module tha has moduleName AND "Teacher" in it.
+            if((modules[i].name.indexOf(moduleName) !== -1) &&
+               (modules[i].name.indexOf("Teacher") !== -1))
+                return modules[i];
+        }
     }
 
     // console.log($routeParams.id);
     $scope.loadPage = function(pageNum) {
 
-    modules.get($routeParams.id, $routeParams.id2)
-    .then(function(retData) {
-      module = retData.data;    
-      return modules.getAll($routeParams.id);
-    }).then(function(retData) {
-      modules = retData.data;
-      // Find the teacher Resource unit for the Unit i.e. the unit with the same
-      // name as the current unit, with "Teacher Resources" in the name.
-      for(i = 0; i < modules.length; i++) {
-        if(modules[i].id == $routeParams.id2) {
-          $scope.module = modules[i];
-          teacherRes = findTeacherRes(modules, module.name);
-        }
-      }
-      return moduleItems.get($routeParams.id, teacherRes.id, 1);
-    }).then(function(retData) {
-      teacherUnitItems = retData.data;
-      return moduleItems.get($routeParams.id, $routeParams.id2, 1);
-    }).then(function(retData) {
-      unitItems = retData.data;
-      $scope.lessonItems = unitItems;
-      countItemTypes(unitItems);
-      for(i = 0; i < teacherUnitItems.length; i++) {
-        if(teacherUnitItems[i].type === "Page") {
-         // find the Unit lesson name, which is the first few characters
-         // up to the ":" in the title of the item i.e. "DM 1: BLah",
-         // "DM 1" is the lesson name.
-          var regEx = /(.*):/;
-          var lessonGrp = regEx.exec(teacherUnitItems[i].title);
-          lessonName = lessonGrp[1].toLowerCase();
-          for(j = 0; j < unitItems.length; j++) {
-            // using toLowerCasse to make the matching case insensitive.
-            var contentItemTitleStr = unitItems[j].title.toLowerCase();
-            if(unitItems[j].type === "SubHeader" &&
-                           (contentItemTitleStr.indexOf(lessonName) !== -1)) {
-              unitItems[j].lessonPlanID = teacherUnitItems[i].id;
-              unitItems[j].lessonPlanUrl = teacherUnitItems[i].html_url;
+        modules.get($routeParams.id, $routeParams.id2)
+        .then(function(retData) {
+            module = retData.data;    
+            return modules.getAll($routeParams.id);
+        }).then(function(retData) {
+            modules = retData.data;
+            // Find the teacher Resource unit for the Unit i.e. the unit with the same
+            // name as the current unit, with "Teacher Resources" in the name.
+            for(i = 0; i < modules.length; i++) {
+                if(modules[i].id == $routeParams.id2) {
+                    $scope.module = modules[i];
+                    teacherRes = findTeacherRes(modules, module.name);
+                }
             }
-          }
-        }
-      }
-      return moduleMetadata.get($routeParams.id2);
-      }).then(function(retData) {
-        $scope.module.learningObjectives = retData.data;
+            return moduleItems.get($routeParams.id, teacherRes.id, 1);
+        }).then(function(retData) {
+            teacherUnitItems = retData.data;
+            return moduleItems.get($routeParams.id, $routeParams.id2, 1);
+        }).then(function(retData) {
+            unitItems = retData.data;
+            $scope.lessonItems = unitItems;
+            countItemTypes(unitItems);
+            for(i = 0; i < teacherUnitItems.length; i++) {
+                if(teacherUnitItems[i].type === "Page") {
+                    // find the Unit lesson name, which is the first few characters
+                    // up to the ":" in the title of the item i.e. "DM 1: BLah",
+                    // "DM 1" is the lesson name.
+                    var regEx = /(.*):/;
+                    var lessonGrp = regEx.exec(teacherUnitItems[i].title);
+                    lessonName = lessonGrp[1].toLowerCase();
+                    for(j = 0; j < unitItems.length; j++) {
+                        // using toLowerCasse to make the matching case insensitive.
+                        var contentItemTitleStr = unitItems[j].title.toLowerCase();
+                        if(unitItems[j].type === "SubHeader" &&
+                           (contentItemTitleStr.indexOf(lessonName) !== -1)) {
+                            unitItems[j].lessonPlanID = teacherUnitItems[i].id;
+                        unitItems[j].lessonPlanUrl = teacherUnitItems[i].html_url;
+                        }
+                    }
+                }
+            }
+            return tags.search({ unitId: $routeParams.id2 });
+        }).then(function(retData) {
+            $scope.module.tags = retData.data;
 
-    }, function(xhr, state, error) {
-        console.log(arguments);
-    });
-}
-$scope.loadPage(1);
+        }, function(xhr, state, error) {
+            console.log(arguments);
+        });
+    }
+    $scope.loadPage(1);
 });

--- a/public/modules/moduleMap.html
+++ b/public/modules/moduleMap.html
@@ -1,9 +1,9 @@
 <div class="modalBody">
-  <h2>{{moduleName}} - Learning Objectives Map</h2>
+  <h2>{{module.name}} - Learning Objectives Map</h2>
 
   <form role="form" ng-submit="addLOs()">
 
-  <learning-objective ng-repeat="lo in unitLOs" expanded id="{{lo}}"></learning-objective>
+    <learning-objective ng-repeat="tag in module.tags" expanded id="{{tag.content}}"></learning-objective>
     <h2>CSP Framework</h2>
 
     <label>Search: <input ng-model="searchText"></label>

--- a/public/modules/modules.html
+++ b/public/modules/modules.html
@@ -30,7 +30,6 @@
     </div>
     </div>
   </div>
-  <learning-objective id="{{lo}}" ng-repeat="lo in module.learningObjectives"></learning-objective>
   <table class="table table-striped">
     <thead>
       <tr>
@@ -45,7 +44,7 @@
         <td><a href="#/courses/{{course.id}}/module/{{module.id}}">{{module.name}}</a></td>
         <td>{{module.items_count}}</td>
         <td>
-          <learning-objective id="{{lo}}" ng-repeat="lo in module.learningObjectives"></learning-objective>
+          <learning-objective id="{{tag.content}}" ng-repeat="tag in module.tags"></learning-objective>
         </td>
         <td>
           <button class="btn btn-default" ng-click="open('lg', module)">Edit LO's</button>

--- a/public/modules/modulesController.js
+++ b/public/modules/modulesController.js
@@ -1,5 +1,5 @@
 angular.module('newApp')
-.controller('modules', function(courses, modules, moduleMetadata, $modal, $log, $scope, $routeParams, $http){
+.controller('modules', function(courses, modules, tags, $modal, $log, $scope, $routeParams, $http){
     function find(modules, courseID) {
         for(i = 0; i < modules.length; i++) {
             if(modules[i].id === courseID)
@@ -34,46 +34,35 @@ angular.module('newApp')
         //       .success block of the previous request), or you have to use promise's to 
         //       syncronize the requests.  If you don't there would be a race condition.
 
-        return moduleMetadata.getAll();
-    }).then(function(retData) {
-            data = retData.data;
-            data.forEach(function(meta) {
-                var module = find($scope.modules, meta.moduleID);
+        return tags.search();
+    }).then(function(response) {
+        response.data.forEach(function(tag) {
+            var module = find($scope.modules, tag.unitId);
 
-                if(module)
-                    module.learningObjectives = (module.learningObjectives || []).concat(meta.learningObjective);
-            });
+            if(module)
+                module.tags = (module.tags || []).concat(tag);
+        });
     }, function(xhr, status, error) {
         // do something with errors
     });
 
     $scope.open = function (size, module) {
 
-      var modalInstance = $modal.open({
-        animation: true,
-        templateUrl: 'modules/moduleMap.html',
-        controller: 'modalModuleMap',
-        size: size,
-        resolve: {
-          unitLOs: function () {
-            return module.learningObjectives;
-          },
-          moduleName: function() {
-            return module.name;
-          }
-        }
-      });
+        var modalInstance = $modal.open({
+            animation: true,
+            templateUrl: 'modules/moduleMap.html',
+            controller: 'modalModuleMap',
+            size: size,
+            resolve: {
+                module: function () { return module; }
+            }
+        });
 
-      modalInstance.result.then(function (unitLOs) {
-        $http.put('/api/units/'+module.id, unitLOs)
-            .success(function(units) {
-                module.learningObjectives = units.map(function (unit) {
-                    return unit.learningObjective;
-                });
-            });
-      }, function () {
-        $log.info('Modal canceled at: ' + new Date());
-      });
+        modalInstance.result.then(function (tags) {
+            module.tags = tags;
+        }, function () {
+            $log.info('Modal canceled at: ' + new Date());
+        });
     };
 });
 


### PR DESCRIPTION
I had to re-indent some of the code to use four spaces instead of two, so you may want to check your editor settings.  We can move to two space indentions if you prefer that, but let's do it all at once instead of just some parts.

This PR introduces no new **features**, rather it uses the tag api where the unit metadata api was being used before.  This means that any existing associations will disappear, and you will have to retag units via the modal on the course page.
